### PR TITLE
[4.0] Irrelevent Codes and Comments removed

### DIFF
--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -41,15 +41,15 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
 	</div>
 	<?php endif;
-	if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && $this->item->paginationrelative)
+	if (!empty($this->item->pagination) && !$this->item->paginationposition && $this->item->paginationrelative)
 	{
 		echo $this->item->pagination;
 	}
 	?>
 
-	<?php // Todo Not that elegant would be nice to group the params ?>
-	<?php $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')
-	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author') || $assocParam); ?>
+	
+	<?php $useDefList = $params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')
+	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author') || $assocParam; ?>
 
 	<?php if ($params->get('show_title')) : ?>
 	<div class="page-header">


### PR DESCRIPTION
Pull Request for Issue #32725 .

### Summary of Changes

&& $this->item->pagination removed from https://github.com/joomla/joomla-cms/blob/4.0.0-beta7/components/com_content/tmpl/article/default.php#L43 and Comment and brackets around OR removed from https://github.com/joomla/joomla-cms/blob/4.0.0-beta7/components/com_content/tmpl/article/default.php#L49-L51.

### Documentation Changes Required

None.